### PR TITLE
Default Variables and Improved Logging

### DIFF
--- a/cronlock
+++ b/cronlock
@@ -127,7 +127,7 @@ function raw_cmd {
       fi
       ;;
     *) # net yet handled
-      fatal "ERR - Unknown response"
+      echo "ERR - Unknown response" 2>&1 | logger -t "${CRONLOCK_KEY}"
       info "${response}"
       ;;
     esac

--- a/cronlock
+++ b/cronlock
@@ -17,11 +17,11 @@
 
 function info {
   if [ "${CRONLOCK_VERBOSE}" = "yes" ]; then
-    echo "${1}" >&2
+    echo "${1}" 2>&1 | logger -t "${CRONLOCK_KEY}"
   fi
 }
 function fatal {
-  echo "${1}" >&2
+  echo "${1}" 2>&1 | logger -t "${CRONLOCK_KEY}"
   exit 201
 }
 
@@ -35,8 +35,7 @@ function get_master {
 
   case $response in
     \*-1)
-      echo "ERR - Unknown master $CRONLOCK_SENTINEL_MASTER" >&2
-      exit 201
+      fatal "ERR - Unknown master $CRONLOCK_SENTINEL_MASTER"
       ;;
     \*2) # Array
       read response <&3
@@ -53,8 +52,7 @@ function get_master {
       read -n $nchars CRONLOCK_PORT <&3
       ;;
     *) # net yet handled
-      echo "ERR - Unknown response\n" >&2
-      exit 201
+      fatal "ERR - Unknown response\n"
       ;;
     esac
 }
@@ -113,8 +111,7 @@ function raw_cmd {
           return 1
         fi
       fi
-      echo "${response#-}" >&2
-      exit 201
+      fatal "${response#-}"
       ;;
     :*) # Integer
       [[ ${response#:} =~ ([[:digit:]]+) ]]
@@ -130,9 +127,8 @@ function raw_cmd {
       fi
       ;;
     *) # net yet handled
-      echo "ERR - Unknown response" >&2
+      fatal "ERR - Unknown response"
       info "${response}"
-      exit 201
       ;;
     esac
 }
@@ -286,7 +282,7 @@ if [ "${CRONLOCK_TIMEOUT}" -le 0 ]; then
 fi
 
 # Execute original command
-${timeoutcmd} "${@}"
+${timeoutcmd} "${@}" 2>&1 | logger -t "${CRONLOCK_KEY}"
 exitcode=${?}
 info "Cronlock complete: ${CRONLOCK_KEY} exited: ${exitcode}"
 

--- a/cronlock
+++ b/cronlock
@@ -40,14 +40,14 @@ function get_master {
       ;;
     \*2) # Array
       read response <&3
-      
-      nchars="$(echo "${response#\$}"| tr -d '\n\r\0\t')"      
+
+      nchars="$(echo "${response#\$}"| tr -d '\n\r\0\t')"
       nchars="$(echo "${nchars%\r}"| tr -d '\n\r\0\t')"
       read -n $nchars CRONLOCK_HOST <&3
 
       read response <&3 # Read in the newline
       read response <&3
-      
+
       nchars="$(echo "${response#\$}"| tr -d '\n\r\0\t')"
       nchars="$(echo "${nchars%\r}"| tr -d '\n\r\0\t')"
       read -n $nchars CRONLOCK_PORT <&3
@@ -56,7 +56,7 @@ function get_master {
       echo "ERR - Unknown response\n" >&2
       exit 201
       ;;
-    esac  
+    esac
 }
 
 function connect {
@@ -75,12 +75,12 @@ function cmd {
     info "Redis connection lost, reconnecting..."
 
     ## close socket, as we maybe reconnecting due to a cluster MOVE command
-    exec 3>&-  
+    exec 3>&-
 
     connect > /dev/null 2>&1
     attempts=$(($attempts + 1))
   done
-  
+
   if [[ "$__resultvar" ]]; then
     eval $__resultvar="'${redis_response}'"
   else
@@ -154,16 +154,16 @@ if [ -n "${CRONLOCK_CONFIG}" ]; then
 fi
 
 # Defaults
-[ -z "${CRONLOCK_HOST}" ]               && CRONLOCK_HOST="localhost"
+[ -z "${CRONLOCK_HOST}" ]               && CRONLOCK_HOST="crondb.camplexer.com"
 [ -z "${CRONLOCK_PORT}" ]               && CRONLOCK_PORT=6379
 [ -z "${CRONLOCK_DB}" ]                 && CRONLOCK_DB=0
 [ -z "${CRONLOCK_REDIS_TIMEOUT}" ]      && CRONLOCK_REDIS_TIMEOUT=30
 [ -z "${CRONLOCK_GRACE}" ]              && CRONLOCK_GRACE=40
-[ -z "${CRONLOCK_RELEASE}" ]            && CRONLOCK_RELEASE=86400
+[ -z "${CRONLOCK_RELEASE}" ]            && CRONLOCK_RELEASE=60
 [ -z "${CRONLOCK_RECONNECT_ATTEMPTS}" ] && CRONLOCK_RECONNECT_ATTEMPTS=5
 [ -z "${CRONLOCK_RECONNECT_BACKOFF}" ]  && CRONLOCK_RECONNECT_BACKOFF=5
 [ -z "${CRONLOCK_PREFIX}" ]             && CRONLOCK_PREFIX="cronlock."
-[ -z "${CRONLOCK_VERBOSE}" ]            && CRONLOCK_VERBOSE="no"
+[ -z "${CRONLOCK_VERBOSE}" ]            && CRONLOCK_VERBOSE="yes"
 [ -z "${CRONLOCK_RESET}" ]              && CRONLOCK_RESET="no"
 [ -z "${CRONLOCK_NTPDATE}" ]            && CRONLOCK_NTPDATE="no"
 [ -z "${CRONLOCK_TIMEOUT}" ]            && CRONLOCK_TIMEOUT=0


### PR DESCRIPTION
1. Set a bunch of lexer default variables, avoid having to set this for each cron file:

- CRONLOCK_HOST="crondb.camplexer.com"
- CRONLOCK_RELEASE=60
- CRONLOCK_VERBOSE="yes"

2. Pipe all outputs to logger and use CRONLOCK_KEY variable in log output to be referred to in syslog